### PR TITLE
Fixes GitLab API returning 404 for certain projects

### DIFF
--- a/scripts/check
+++ b/scripts/check
@@ -58,9 +58,13 @@ fi
 
 project_path_encoded="${project_path//'/'/'%2F'}" # url encode "/"
 
+project_id="$(curl \
+--header "PRIVATE-TOKEN: ${private_token}" \
+"${protocol}://${gitlab_host}/api/v3/projects/${project_path_encoded}" | jq '.id')"
+
 open_mrs="$(curl \
 --header "PRIVATE-TOKEN: ${private_token}" \
-"${protocol}://${gitlab_host}/api/v3/projects/${project_path_encoded}/merge_requests?state=opened&order_by=updated_at")"
+"${protocol}://${gitlab_host}/api/v3/projects/${project_id}/merge_requests?state=opened&order_by=updated_at")"
 
 num_mrs="$(echo "${open_mrs}" | jq 'length')"
 

--- a/scripts/out
+++ b/scripts/out
@@ -57,6 +57,10 @@ fi
 
 project_path_encoded="${project_path//'/'/'%2F'}" # url encode "/"
 
+project_id="$(curl \
+--header "PRIVATE-TOKEN: ${private_token}" \
+"${protocol}://${gitlab_host}/api/v3/projects/${project_path_encoded}" | jq '.id')"
+
 target_url="${ATC_EXTERNAL_URL}/teams/${BUILD_TEAM_NAME}/pipelines/${BUILD_PIPELINE_NAME}/jobs/${BUILD_JOB_NAME}/builds/${BUILD_NAME}"
 
 cd "${destination}"
@@ -69,7 +73,7 @@ curl \
 --header "PRIVATE-TOKEN: ${private_token}" \
 --header "Content-Type: application/json" \
 --data "{\"state\":\"${new_status}\",\"name\":\"Concourse\",\"target_url\":\"${target_url}\"}" \
-"${protocol}://${gitlab_host}/api/v3/projects/${project_path_encoded}/statuses/${commit_sha}"
+"${protocol}://${gitlab_host}/api/v3/projects/${project_id}/statuses/${commit_sha}"
 
 version="{\"sha\":\"${commit_sha}\"}"
 


### PR DESCRIPTION
Workaround for an API issue to prevent merge request endpoint from returning 404.

It is possible to see the details of the project using the URL encoded project name, but it doesn't work with the merge request endpoint. So we basically retrieve the project ID and use it instead. 