### PR TITLE
fix spaces in BUILD_JOB_NAMES

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -78,3 +78,7 @@ configure_ssl_verification() {
       echo insecure > $HOME/.curlrc
     fi
 }
+
+urlencode() {
+  echo -n "${1}" | jq -s -R -r @uri
+}

--- a/scripts/out
+++ b/scripts/out
@@ -58,7 +58,7 @@ fi
 project_path_encoded="${project_path//\//%2F}" # url encode "/"
 project_path_encoded="${project_path_encoded//./%2E}" # url encode "."
 
-target_url="${ATC_EXTERNAL_URL}/teams/${BUILD_TEAM_NAME}/pipelines/${BUILD_PIPELINE_NAME}/jobs/${BUILD_JOB_NAME}/builds/${BUILD_NAME}"
+target_url="${ATC_EXTERNAL_URL}/teams/$(urlencode ${BUILD_TEAM_NAME})/pipelines/$(urlencode ${BUILD_PIPELINE_NAME})/jobs/$(urlencode ${BUILD_JOB_NAME})/builds/$(urlencode ${BUILD_NAME})"
 
 cd "${destination}"
 cd "${path_to_repo}"


### PR DESCRIPTION
When using gitlab-merge-request-resource we experienced the issue, that concourse could not update the status in gitlab for jobs with spaces and brackets in the name. Encoding the respective environment variables fixed the problem for us.

Here the error message we got before:
`{"message":{"target_url":["must be a valid URL"]}}`