### PR TITLE
Fix check script for git uri's

### DIFF
--- a/scripts/check
+++ b/scripts/check
@@ -2,7 +2,6 @@
 # vim: set ft=sh
 
 set -e -u
-
 exec 3>&1 # make stdout available as fd 3 for the result
 exec 1>&2 # redirect all output to stderr for logging
 
@@ -18,12 +17,19 @@ configure_ssl_verification "${payload}"
 
 uri="$(jq -r '.source.uri // ""' < "${payload}")"
 private_token="$(jq -r '.source.private_token // ""' < "${payload}")"
+private_key="$(jq -r '.source.private_key // ""' < "${payload}")"
 no_ssl="$(jq -r '.source.no_ssl // ""' < "${payload}")"
 version_sha="$(jq -r '.version.sha // ""' < "${payload}")"
 
-gitlab_host="$(echo "${uri}" | sed -rn 's/(https?):\/\/([^\/]*)\/(.*)\.git/\2/p')"
-project_path="$(echo "${uri}" | sed -rn 's/(https?):\/\/([^\/]*)\/(.*)\.git/\3/p')"
-protocol="$(echo "${uri}" | sed -rn 's/(https?):\/\/([^\/]*)\/(.*)\.git/\1/p')"
+if [[ ! -z "${private_key}" ]]; then
+  gitlab_host="$(echo "${uri}" | sed -rn 's/git@(.*):(.*)\.git/\1/p')"
+  project_path="$(echo "${uri}" | sed -rn 's/git@(.*):(.*)\.git/\2/p')"
+  protocol='https'
+else
+  gitlab_host="$(echo "${uri}" | sed -rn 's/(https?):\/\/([^\/]*)\/(.*)\.git/\2/p')"
+  project_path="$(echo "${uri}" | sed -rn 's/(https?):\/\/([^\/]*)\/(.*)\.git/\3/p')"
+  protocol="$(echo "${uri}" | sed -rn 's/(https?):\/\/([^\/]*)\/(.*)\.git/\1/p')"
+fi
 
 if [ "${no_ssl}" == 'true' ]; then
     protocol='http'

--- a/scripts/check
+++ b/scripts/check
@@ -2,6 +2,7 @@
 # vim: set ft=sh
 
 set -e -u
+
 exec 3>&1 # make stdout available as fd 3 for the result
 exec 1>&2 # redirect all output to stderr for logging
 
@@ -17,11 +18,10 @@ configure_ssl_verification "${payload}"
 
 uri="$(jq -r '.source.uri // ""' < "${payload}")"
 private_token="$(jq -r '.source.private_token // ""' < "${payload}")"
-private_key="$(jq -r '.source.private_key // ""' < "${payload}")"
 no_ssl="$(jq -r '.source.no_ssl // ""' < "${payload}")"
 version_sha="$(jq -r '.version.sha // ""' < "${payload}")"
 
-if [[ ! -z "${private_key}" ]]; then
+if [[ "${uri}" == "git@"* ]]; then
   gitlab_host="$(echo "${uri}" | sed -rn 's/git@(.*):(.*)\.git/\1/p')"
   project_path="$(echo "${uri}" | sed -rn 's/git@(.*):(.*)\.git/\2/p')"
   protocol='https'


### PR DESCRIPTION
Issue: For git@gitlab.foo.com:name/repo.git uri's the check script was broken as the regex assumes a https uri 

Fix: check for private_key and if present assume git uri and use different regex 