### PR TITLE
Updated Regex patterns to support private GitLab servers

### DIFF
--- a/scripts/check
+++ b/scripts/check
@@ -21,9 +21,11 @@ private_token="$(jq -r '.source.private_token // ""' < "${payload}")"
 no_ssl="$(jq -r '.source.no_ssl // ""' < "${payload}")"
 version_sha="$(jq -r '.version.sha // ""' < "${payload}")"
 
-if [[ "${uri}" == "git@"* ]]; then
-  gitlab_host="$(echo "${uri}" | sed -rn 's/git@(.*):(.*)\.git/\1/p')"
-  project_path="$(echo "${uri}" | sed -rn 's/git@(.*):(.*)\.git/\2/p')"
+if [[ "${uri}" == *"git@"* ]]; then
+  gitlab_host="$(echo "${uri}" | sed -rn 's/.*git@(.*):([0-9]*\/+)?(.*)\.git/\1/p')"
+  port="$(echo "${uri}" | sed -rn 's/.*git@(.*):([0-9]*\/+)?(.*)\.git/\2/p')"
+  port=${port///} # remove trailing slash
+  project_path="$(echo "${uri}" | sed -rn 's/.*git@(.*):([0-9]*\/+)?(.*)\.git/\3/p')"
   protocol='https'
 else
   gitlab_host="$(echo "${uri}" | sed -rn 's/(https?):\/\/([^\/]*)\/(.*)\.git/\2/p')"

--- a/scripts/in
+++ b/scripts/in
@@ -31,13 +31,20 @@ version="$(jq -r '.version // ""' < "${payload}")"
 commit_sha="$(echo "${version}" | jq -r '.sha // ""')"
 
 if [[ ! -z "${private_key}" ]]; then
-    gitlab_host="$(echo "${uri}" | sed -rn 's/git@(.*):(.*)\.git/\1/p')"
+    gitlab_host="$(echo "${uri}" | sed -rn 's/.*git@(.*):([0-9]*\/+)?(.*)\.git/\1/p')"
+    port="$(echo "${uri}" | sed -rn 's/.*git@(.*):([0-9]*\/+)?(.*)\.git/\2/p')"
+    port=${port///} # remove trailing slash
 
     id_rsa="${HOME}/.ssh/id_rsa"
     mkdir -p "${HOME}/.ssh/"
     echo "${private_key}" > "${id_rsa}"
     chmod 500 "${id_rsa}"
-    ssh-keyscan -t rsa "${gitlab_host}" > "${HOME}/.ssh/known_hosts"
+
+    if [[ ! -z "${port}" ]]; then
+        ssh-keyscan -t rsa -p "${port}" "${gitlab_host}" > "${HOME}/.ssh/known_hosts"
+    else
+        ssh-keyscan -t rsa "${gitlab_host}" > "${HOME}/.ssh/known_hosts"
+    fi
 else
     echo "default login ${username} password ${password}" > "${HOME}/.netrc" # Save credentials for git push below
 fi

--- a/scripts/out
+++ b/scripts/out
@@ -44,8 +44,10 @@ gitlab_host=''
 project_path=''
 protocol='https'
 if [[ ! -z "${private_key}" ]]; then
-    gitlab_host="$(echo "${uri}" | sed -rn 's/git@(.*):(.*)\.git/\1/p')"
-    project_path="$(echo "${uri}" | sed -rn 's/git@(.*):(.*)\.git/\2/p')"
+    gitlab_host="$(echo "${uri}" | sed -rn 's/.*git@(.*):([0-9]*\/+)?(.*)\.git/\1/p')"
+    port="$(echo "${uri}" | sed -rn 's/.*git@(.*):([0-9]*\/+)?(.*)\.git/\2/p')"
+    port=${port///} # remove trailing slash
+    project_path="$(echo "${uri}" | sed -rn 's/.*git@(.*):([0-9]*\/+)?(.*)\.git/\3/p')"
 else
     gitlab_host="$(echo "${uri}" | sed -rn 's/(https?):\/\/([^\/]*)\/(.*)\.git/\2/p')"
     project_path="$(echo "${uri}" | sed -rn 's/(https?):\/\/([^\/]*)\/(.*)\.git/\3/p')"


### PR DESCRIPTION
Closes #17

The previous Regex patterns used in "check" and "in" did not support SSH endpoints to private GitLab servers (i.e. did not support non-default ports). Updated Regex patterns to support both public and private repositories by using an optional capture group.