### PR TITLE
feat(api): Switch to gitlab api v4

### DIFF
--- a/scripts/check
+++ b/scripts/check
@@ -39,11 +39,11 @@ fi
 
 version_updated_at=0
 if [ ! -z "${version_sha}" ]; then
-    version_updated_at="$(curl -s -H "private-token: ${private_token}" "${protocol}://${gitlab_host}/api/v3/projects/$(urlencode "${project_path}")/repository/commits/${version_sha}" \
+    version_updated_at="$(curl -s -H "private-token: ${private_token}" "${protocol}://${gitlab_host}/api/v4/projects/$(urlencode "${project_path}")/repository/commits/${version_sha}" \
         | jq '.committed_date|.[:19]|strptime("%Y-%m-%dT%H:%M:%S")|mktime')"
 fi
 
-open_mrs="$(curl -s -H "private-token: ${private_token}" "${protocol}://${gitlab_host}/api/v3/projects/$(urlencode "${project_path}")/merge_requests?state=opened&order_by=updated_at")"
+open_mrs="$(curl -s -H "private-token: ${private_token}" "${protocol}://${gitlab_host}/api/v4/projects/$(urlencode "${project_path}")/merge_requests?state=opened&order_by=updated_at")"
 num_mrs="$(echo "${open_mrs}" | jq 'length')"
 
 new_versions=''
@@ -52,7 +52,7 @@ for i in $(seq 0 $((num_mrs - 1))); do
     mr="$(echo "${open_mrs}" | jq -r '.['"$i"']')"
     mr_sha="$(echo "${mr}" | jq -r '.sha')"
     if [ "${mr_sha}" != "null" ]; then
-        mr_updated_at="$(curl -s -H "private-token: ${private_token}" "${protocol}://${gitlab_host}/api/v3/projects/$(urlencode "${project_path}")/repository/commits/${mr_sha}" \
+        mr_updated_at="$(curl -s -H "private-token: ${private_token}" "${protocol}://${gitlab_host}/api/v4/projects/$(urlencode "${project_path}")/repository/commits/${mr_sha}" \
             | jq '.committed_date|.[:19]|strptime("%Y-%m-%dT%H:%M:%S")|mktime')"
         if [ "${mr_updated_at}" -gt "${version_updated_at}" ] || [ -z "${version_sha}" ]; then
             new_versions="${new_versions},{\"sha\":\"${mr_sha}\"}"

--- a/scripts/out
+++ b/scripts/out
@@ -70,7 +70,7 @@ curl \
     --header "PRIVATE-TOKEN: ${private_token}" \
     --header 'Content-Type: application/json' \
     --data "{\"state\":\"${new_status}\",\"name\":\"${build_label}\",\"target_url\":\"${target_url}\"}" \
-    "${protocol}://${gitlab_host}/api/v3/projects/$(urlencode "${project_path}")/statuses/${commit_sha}"
+    "${protocol}://${gitlab_host}/api/v4/projects/$(urlencode "${project_path}")/statuses/${commit_sha}"
 
 version="{\"sha\":\"${commit_sha}\"}"
 


### PR DESCRIPTION
	Switch from gitlab api v3 to v4

Closes:

Online gitlab.com does not support v3 any more. Looks like simple rewrite from v3 to v4 is what we need. 