### PR TITLE
Saves additional metadata in files in the .git directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,3 +2,7 @@ FROM concourse/buildroot:git
 
 COPY scripts/ /opt/resource/
 RUN chmod +x /opt/resource/*
+
+# DEVOPS-596 - removes AddTrust certificates from /etc/ssl/certs as they have expired and
+# directly impact our gitlab server.
+RUN rm -f /etc/ssl/certs/AddTrust_*

--- a/scripts/check
+++ b/scripts/check
@@ -20,6 +20,7 @@ uri="$(jq -r '.source.uri // ""' < "${payload}")"
 private_token="$(jq -r '.source.private_token // ""' < "${payload}")"
 no_ssl="$(jq -r '.source.no_ssl // ""' < "${payload}")"
 version_sha="$(jq -r '.version.sha // ""' < "${payload}")"
+branch="$(jq -r '.version.branch // ""' < "${payload}")"
 
 if [[ "${uri}" == *"git@"* ]]; then
   gitlab_host="$(echo "${uri}" | sed -rn 's/.*git@(.*):([0-9]*\/+)?(.*)\.git/\1/p')"
@@ -43,19 +44,22 @@ if [ ! -z "${version_sha}" ]; then
         | jq '.committed_date|.[:19]|strptime("%Y-%m-%dT%H:%M:%S")|mktime')"
 fi
 
-open_mrs="$(curl -s -H "private-token: ${private_token}" "${protocol}://${gitlab_host}/api/v4/projects/$(urlencode "${project_path}")/merge_requests?state=opened&order_by=updated_at")"
+open_mrs="$(curl -s -H "private-token: ${private_token}" "${protocol}://${gitlab_host}/api/v4/projects/$(urlencode "${project_path}")/merge_requests?state=opened&order_by=updated_at&work_in_progress=false")"
 num_mrs="$(echo "${open_mrs}" | jq 'length')"
 
 new_versions=''
 
 for i in $(seq 0 $((num_mrs - 1))); do
     mr="$(echo "${open_mrs}" | jq -r '.['"$i"']')"
+    mr_target_branch="$(echo "${mr}" | jq -r '.target_branch')"
+    mr_wip="$(echo "${mr}" | jq -r '.work_in_progress')"
     mr_sha="$(echo "${mr}" | jq -r '.sha')"
+    mr_branch="$(echo "${mr}" | jq -r '.source_branch')"
     if [ "${mr_sha}" != "null" ]; then
         mr_updated_at="$(curl -s -H "private-token: ${private_token}" "${protocol}://${gitlab_host}/api/v4/projects/$(urlencode "${project_path}")/repository/commits/${mr_sha}" \
             | jq '.committed_date|.[:19]|strptime("%Y-%m-%dT%H:%M:%S")|mktime')"
         if [ "${mr_updated_at}" -gt "${version_updated_at}" ] || [ -z "${version_sha}" ]; then
-            new_versions="${new_versions},{\"sha\":\"${mr_sha}\"}"
+            new_versions="${new_versions},{\"sha\":\"${mr_sha}\", \"branch\":\"${mr_branch}\"}"
         fi
     fi
 done
@@ -64,7 +68,7 @@ new_versions="${new_versions#','}" # remove trailing comma
 new_versions="[${new_versions}]" # make JSON array
 
 if [ "${new_versions}" == '[]' ] && ! [ -z "${version_sha}" ]; then
-    new_versions="[{\"sha\":\"${version_sha}\"}]"
+    new_versions="[{\"sha\":\"${version_sha}\", \"branch\":\"${branch}\"}]"
 fi
 
 jq -n "${new_versions}" >&3

--- a/scripts/check
+++ b/scripts/check
@@ -44,7 +44,7 @@ if [ ! -z "${version_sha}" ]; then
         | jq '.committed_date|.[:19]|strptime("%Y-%m-%dT%H:%M:%S")|mktime')"
 fi
 
-open_mrs="$(curl -s -H "private-token: ${private_token}" "${protocol}://${gitlab_host}/api/v4/projects/$(urlencode "${project_path}")/merge_requests?state=opened&order_by=updated_at&work_in_progress=false")"
+open_mrs="$(curl -s -H "private-token: ${private_token}" "${protocol}://${gitlab_host}/api/v4/projects/$(urlencode "${project_path}")/merge_requests?state=opened&order_by=updated_at&wip=no" | jq '[ .[] | select (.target_branch == "master") | select(.merge_status=="can_be_merged")]')"
 num_mrs="$(echo "${open_mrs}" | jq 'length')"
 
 new_versions=''

--- a/scripts/in
+++ b/scripts/in
@@ -28,7 +28,9 @@ username="$(jq -r '.source.username // ""' < "${payload}")"
 password="$(jq -r '.source.password // ""' < "${payload}")"
 private_key="$(jq -r '.source.private_key // ""' < "${payload}")"
 version="$(jq -r '.version // ""' < "${payload}")"
+
 commit_sha="$(echo "${version}" | jq -r '.sha // ""')"
+branch="$(echo "${version}" | jq -r '.branch // ""')"
 
 if [[ ! -z "${private_key}" ]]; then
     gitlab_host="$(echo "${uri}" | sed -rn 's/.*git@(.*):([0-9]*\/+)?(.*)\.git/\1/p')"
@@ -53,6 +55,11 @@ git clone "${uri}" "${destination}"
 
 cd "${destination}"
 
+echo "${branch}" >.git/branch
+echo "${commit_sha}" >.git/commit_sha
+echo "${uri}" >.git/project_id
+
+git checkout ${branch}
 git reset --hard "${commit_sha}"
 
 jq -n "{

--- a/scripts/out
+++ b/scripts/out
@@ -64,6 +64,7 @@ cd "${destination}"
 cd "${path_to_repo}"
 
 commit_sha="$(git rev-parse HEAD)"
+branch="$(cat .git/branch)"
 
 curl \
     --request POST \
@@ -72,7 +73,7 @@ curl \
     --data "{\"state\":\"${new_status}\",\"name\":\"${build_label}\",\"target_url\":\"${target_url}\"}" \
     "${protocol}://${gitlab_host}/api/v4/projects/$(urlencode "${project_path}")/statuses/${commit_sha}"
 
-version="{\"sha\":\"${commit_sha}\"}"
+version="{\"sha\":\"${commit_sha}\", \"branch\":\"${branch}\"}"
 
 jq -n "{
     version: ${version},


### PR DESCRIPTION
Restricts MR's to those that are not WIP.

* Additional files are:
  * branch <- the name of the branch that the MR has come from
  * project_id <- the uri of the repo
  * commit_sha <- the sha of the commit

This is useful information for tools like SonarQube, and in addition
keeps the metadata of the MR check, in, and out consistent with
reality.